### PR TITLE
RequestProcessorQueue

### DIFF
--- a/include/whaleroute/detail/route.h
+++ b/include/whaleroute/detail/route.h
@@ -88,30 +88,28 @@ private:
     }
 
     template<typename T = TRequestType>
-    auto processRequest(const TRequest &request, TResponse& response) -> std::enable_if_t<!std::is_same_v<T, _>, bool>
+    auto getRequestProcessor(const TRequest &request, TResponse& response) -> std::enable_if_t<!std::is_same_v<T, _>, std::vector<ProcessingFunc>>
     {
-        auto matched = false;
+        auto result = std::vector<ProcessingFunc>{};
         for (auto& processor : processorList_){
             auto[requestType, processingFunc] = processor;
             if (requestType.isAny() ||
                 requestType == router_.getRequestType(request)){
-                processingFunc(request, response);
-                matched = true;
+                result.emplace_back(std::move(processingFunc));
             }
         }
-        return matched;
+        return result;
     }
 
     template<typename T = TRequestType>
-    auto processRequest(const TRequest &request, TResponse& response) -> std::enable_if_t<std::is_same_v<T, _>, bool>
+    auto getRequestProcessor(const TRequest &request, TResponse& response) -> std::enable_if_t<std::is_same_v<T, _>, std::vector<ProcessingFunc>>
     {
-        auto matched = false;
+        auto result = std::vector<ProcessingFunc>{};
         for (auto& processor : processorList_){
             auto[requestType, processingFunc] = processor;
-            processingFunc(request, response);
-            matched = true;
+            result.emplace_back(std::move(processingFunc));
         }
-        return matched;
+        return result;
     }
 
 private:

--- a/include/whaleroute/detail/utils.h
+++ b/include/whaleroute/detail/utils.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <algorithm>
+
+namespace whaleroute::detail {
+
+template<typename TDst, typename TSrc>
+void concat(TDst& dst, const TSrc& src)
+{
+    std::copy(std::begin(src), std::end(src), std::inserter(dst, std::end(dst)));
+}
+
+}

--- a/include/whaleroute/requestprocessorqueue.h
+++ b/include/whaleroute/requestprocessorqueue.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <optional>
+
+namespace whaleroute{
+
+class RequestProcessorQueue{
+public:
+    explicit RequestProcessorQueue(std::vector<std::function<std::optional<bool>()>> requestProcessorInvokers,
+                                   std::function<void()> unmatchedRequestHandler)
+        : requestProcessorInvokers_(std::move(requestProcessorInvokers))
+        , unmatchedRequestHandler_(std::move(unmatchedRequestHandler))
+    {}
+    RequestProcessorQueue() = default;
+
+    void launch()
+    {
+        isStopped_ = false;
+        for (; currentIndex_ < requestProcessorInvokers_.size(); ++currentIndex_){
+            if (isStopped_)
+                break;
+            auto result = requestProcessorInvokers_.at(currentIndex_)();
+            if (!result)
+                unmatchedRequestHandler_();
+            else if (!*result){
+                currentIndex_ = static_cast<int>(requestProcessorInvokers_.size()) + 1;
+                break;
+            }
+        }
+    }
+
+    void stop()
+    {
+        isStopped_ = true;
+    }
+
+private:
+    int currentIndex_ = 0;
+    bool isStopped_ = false;
+    std::vector<std::function<std::optional<bool>()>> requestProcessorInvokers_;
+    std::function<void()> unmatchedRequestHandler_;
+};
+
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <memory>
 
 struct TestState{
     bool activated = false;
@@ -15,8 +16,15 @@ struct Request{
     std::string name;
 };
 struct Response{
-    std::string data;
-    bool wasSent = false;
+    void init()
+    {
+        state = std::make_shared<State>();
+    }
+    struct State {
+        std::string data;
+        bool wasSent = false;
+    };
+    std::shared_ptr<State> state;
 };
 struct ResponseValue{
     std::string data;

--- a/tests/test_access.cpp
+++ b/tests/test_access.cpp
@@ -18,8 +18,9 @@ state_.activated = false;
 void processRequest(RequestType type, const std::string& path)
 {
     auto response = Response{};
+    response.init();
     process(Request{type, path}, response);
-    responseData_ = response.data;
+    responseData_ = response.state->data;
 }
 
 void expectNoMatch()
@@ -98,13 +99,13 @@ return request.type;
 
 void processUnmatchedRequest(const Request&, Response& response) final
 {
-response.data = "NO_MATCH";
+    response.state->data = "NO_MATCH";
 }
 
 void setResponseValue(Response& response, const ResponseValue& value) final
 {
-state_.activated = true;
-response.data = value.data;
+    state_.activated = true;
+    response.state->data = value.data;
 }
 
 std::function<void(const Request&, Response& response)>
@@ -141,7 +142,7 @@ checkResponse("Hello world");
 TEST_P(AccessTestingRouter, Process)
 {
 route("/", RequestType::GET, accessType_).process(makeProcessor([](const Request&, Response& response) {
-    response.data = "Hello world";
+    response.state->data = "Hello world";
 }));
 
 processRequest(RequestType::GET, "/");
@@ -151,7 +152,7 @@ checkResponse("Hello world");
 TEST_P(AccessTestingRouter, ProcessAnyRequestType)
 {
     route("/", whaleroute::_{}, accessType_).process(makeProcessor([](const Request&, Response& response) {
-        response.data = "Hello world";
+        response.state->data = "Hello world";
     }));
 
     processRequest(RequestType::POST, "/");
@@ -162,7 +163,7 @@ TEST_P(AccessTestingRouter, ProcessWithRegexp)
 {
 route(std::regex{R"(/page\d*)"}, RequestType::GET, accessType_).process(
         makeProcessor([](const Request&, Response& response) {
-    response.data = "Hello world";
+    response.state->data = "Hello world";
 }));
 
 processRequest(RequestType::GET, "/page123");

--- a/tests/test_router.cpp
+++ b/tests/test_router.cpp
@@ -10,8 +10,9 @@ public:
     void processRequest(RequestType type, const std::string& path, const std::string& name = {})
     {
         auto response = Response{};
+        response.init();
         process(Request{type, path, name}, response);
-        responseData_ = response.data;
+        responseData_ = response.state->data;
     }
 
     void checkResponse(const std::string& expectedResponseData)
@@ -31,11 +32,11 @@ protected:
 
     void processUnmatchedRequest(const Request&, Response& response) final
     {
-        response.data = "NO_MATCH";
+        response.state->data = "NO_MATCH";
     }
     void setResponseValue(Response& response, const std::string& value) final
     {
-        response.data = value;
+        response.state->data = value;
     }
 
     void callRequestProcessor(RequestProcessor& processor, const Request& request, Response& response) final
@@ -52,9 +53,9 @@ class StatelessRouteProcessor : public RequestProcessor
     void process(const Request& request, Response& response) override
     {
         if (!request.name.empty())
-            response.data = "Hello " + request.name;
+            response.state->data = "Hello " + request.name;
         else
-            response.data = "/name-not-found";
+            response.state->data = "/name-not-found";
     }
 };
 
@@ -63,7 +64,7 @@ TEST_F(Router, StatelessRouteProcessor){
     auto processor = StatelessRouteProcessor{};
     route("/greet2", RequestType::GET).process(processor);
     route("/", RequestType::GET).set("Hello world");
-    route("/any", whaleroute::_{}).process([](const Request& request, Response& response){ response.data = "Any!";});
+    route("/any", whaleroute::_{}).process([](const Request& request, Response& response){ response.state->data = "Any!";});
     route(std::regex{"/greet/.*"}, RequestType::GET).process<StatelessRouteProcessor>();
     route().set("/404");
 
@@ -104,12 +105,12 @@ public:
 
         if (request.requestPath == "/" || request.requestPath == "/test"){
             if (state_.name.empty())
-                response.data  = "OK";
+                response.state->data  = "OK";
             else
-                response.data = "Hello " + state_.name;
+                response.state->data = "Hello " + state_.name;
         }
         else
-            response.data =  "/";
+            response.state->data =  "/";
     }
 
     NameState& state_;
@@ -166,7 +167,7 @@ public:
     void process(const Request&, Response& response) override
     {
         state_ = ++counter;
-        response.data = "TEST";
+        response.state->data = "TEST";
     }
 
 private:

--- a/tests/test_router_without_processor.cpp
+++ b/tests/test_router_without_processor.cpp
@@ -10,8 +10,9 @@ public:
     void processRequest(RequestType type, const std::string& path)
     {
         auto response = Response{};
+        response.init();
         process(Request{type, path}, response);
-        responseData_ = response.data;
+        responseData_ = response.state->data;
     }
 
     void checkResponse(const std::string& expectedResponseData)
@@ -32,12 +33,12 @@ protected:
 
     void processUnmatchedRequest(const Request&, Response& response) final
     {
-        response.data = "NO_MATCH";
+        response.state->data = "NO_MATCH";
     }
 
     void setResponseValue(Response& response, const std::string& value) final
     {
-        response.data = value;
+        response.state->data = value;
     }
 
 protected:
@@ -57,13 +58,13 @@ TEST_F(RouterWithoutProcessor, MultipleRoutes)
 {
     route("/", RequestType::GET).set("Hello world");
     route("/page0", RequestType::GET).set("Default page");
-    route("/any", whaleroute::_{}).process([](const Request& request, Response& response){ response.data = "Any!";});
+    route("/any", whaleroute::_{}).process([](const Request& request, Response& response){ response.state->data = "Any!";});
     route(std::regex{R"(/page\d*)"}, RequestType::GET).set("Some page");
     route("/upload", RequestType::POST).set("OK");
     route(std::regex{R"(/files/.*\.xml)"}, RequestType::GET).process(
             [](const Request&, Response& response) {
                 auto fileContent = std::string{"testXML"};
-                response.data = fileContent;
+                response.state->data = fileContent;
             });
     route().set("404");
 

--- a/tests/test_router_without_processor_and_request_type.cpp
+++ b/tests/test_router_without_processor_and_request_type.cpp
@@ -10,8 +10,9 @@ public:
     void processRequest(RequestType type, const std::string& path)
     {
         auto response = Response{};
+        response.init();
         process(Request{type, path}, response);
-        responseData_ = response.data;
+        responseData_ = response.state->data;
     }
 
     void checkResponse(const std::string& expectedResponseData)
@@ -27,12 +28,12 @@ protected:
 
     void processUnmatchedRequest(const Request&, Response& response) final
     {
-        response.data = "NO_MATCH";
+        response.state->data = "NO_MATCH";
     }
 
     void setResponseValue(Response& response, const std::string& value) final
     {
-        response.data = value;
+        response.state->data = value;
     }
 
 protected:
@@ -57,7 +58,7 @@ TEST_F(RouterWithoutProcessorAndRequestType, MultipleRoutes)
     route(std::regex{R"(/files/.*\.xml)"}).process(
             [](const Request&, Response& response) {
                 auto fileContent = std::string{"testXML"};
-                response.data = fileContent;
+                response.state->data = fileContent;
             });
     route().set("404");
 

--- a/tests/test_router_without_request_type.cpp
+++ b/tests/test_router_without_request_type.cpp
@@ -10,8 +10,9 @@ public:
     void processRequest(const std::string& path, const std::string& name = {})
     {
         auto response = Response{};
+        response.init();
         process(Request{RequestType::GET, path, name}, response);
-        responseData_ = response.data;
+        responseData_ = response.state->data;
     }
 
     void checkResponse(const std::string& expectedResponseData)
@@ -27,7 +28,7 @@ protected:
 
     void processUnmatchedRequest(const Request&, Response& response) final
     {
-        response.data = "NO_MATCH";
+        response.state->data = "NO_MATCH";
     }
 
     void callRequestProcessor(RequestProcessor& processor, const Request& request, Response& response) final
@@ -37,7 +38,7 @@ protected:
 
     void setResponseValue(Response& response, const std::string& value) final
     {
-        response.data = value;
+        response.state->data = value;
     }
 
 protected:
@@ -48,9 +49,9 @@ class StatelessRouteProcessor : public RequestProcessor {
     void process(const Request& request, Response& response) override
     {
         if (!request.name.empty())
-            response.data = "Hello " + request.name;
+            response.state->data = "Hello " + request.name;
         else
-            response.data = "/name-not-found";
+            response.state->data = "/name-not-found";
     }
 };
 
@@ -59,9 +60,9 @@ TEST_F(RouterWithoutRequestType, StatelessRouteProcessor)
     route("/greet").process<StatelessRouteProcessor>();
     auto processor = StatelessRouteProcessor{};
     route("/greet2").process(processor);
-    route("/").process([](auto&, auto& response){ response.data = "Hello world";});
+    route("/").process([](auto&, auto& response){ response.state->data = "Hello world";});
     route(std::regex{"/greet/.*"}).process<StatelessRouteProcessor>();
-    route().process([](auto&, auto& response){ response.data = "/404";});
+    route().process([](auto&, auto& response){ response.state->data = "/404";});
 
     processRequest("/");
     checkResponse("Hello world");
@@ -96,11 +97,11 @@ public:
 
         if (request.requestPath == "/" || request.requestPath == "/test") {
             if (state_.name.empty())
-                response.data = "OK";
+                response.state->data = "OK";
             else
-                response.data = "Hello " + state_.name;
+                response.state->data = "Hello " + state_.name;
         } else
-            response.data = "/";
+            response.state->data = "/";
     }
 
     NameState& state_;
@@ -157,7 +158,7 @@ public:
     void process(const Request&, Response& response) override
     {
         state_ = ++counter;
-        response.data = "TEST";
+        response.state->data = "TEST";
     }
 
 private:

--- a/tests/test_router_without_request_type_and_response_value.cpp
+++ b/tests/test_router_without_request_type_and_response_value.cpp
@@ -10,8 +10,9 @@ public:
     void processRequest(const std::string& path, const std::string& name = {})
     {
         auto response = Response{};
+        response.init();
         process(Request{RequestType::GET, path, name}, response);
-        responseData_ = response.data;
+        responseData_ = response.state->data;
     }
 
     void checkResponse(const std::string& expectedResponseData)
@@ -27,7 +28,7 @@ protected:
 
     void processUnmatchedRequest(const Request&, Response& response) final
     {
-        response.data = "NO_MATCH";
+        response.state->data = "NO_MATCH";
     }
 
     void callRequestProcessor(RequestProcessor& processor, const Request& request, Response& response) final
@@ -43,9 +44,9 @@ class StatelessRouteProcessor : public RequestProcessor {
     void process(const Request& request, Response& response) override
     {
         if (!request.name.empty())
-            response.data = "Hello " + request.name;
+            response.state->data = "Hello " + request.name;
         else
-            response.data = "/name-not-found";
+            response.state->data = "/name-not-found";
     }
 };
 
@@ -54,9 +55,9 @@ TEST_F(RouterWithoutRequestTypeAndResponseValue, StatelessRouteProcessor)
     route("/greet").process<StatelessRouteProcessor>();
     auto processor = StatelessRouteProcessor{};
     route("/greet2").process(processor);
-    route("/").process([](auto&, auto& response){ response.data = "Hello world";});
+    route("/").process([](auto&, auto& response){ response.state->data = "Hello world";});
     route(std::regex{"/greet/.*"}).process<StatelessRouteProcessor>();
-    route().process([](auto&, auto& response){ response.data = "/404";});
+    route().process([](auto&, auto& response){ response.state->data = "/404";});
 
     processRequest("/");
     checkResponse("Hello world");
@@ -91,11 +92,11 @@ public:
 
         if (request.requestPath == "/" || request.requestPath == "/test") {
             if (state_.name.empty())
-                response.data = "OK";
+                response.state->data = "OK";
             else
-                response.data = "Hello " + state_.name;
+                response.state->data = "Hello " + state_.name;
         } else
-            response.data = "/";
+            response.state->data = "/";
     }
 
     NameState& state_;
@@ -152,7 +153,7 @@ public:
     void process(const Request&, Response& response) override
     {
         state_ = ++counter;
-        response.data = "TEST";
+        response.state->data = "TEST";
     }
 
 private:


### PR DESCRIPTION
Now route matching result is placed in the queue. This is neccessary for async request processors - a queue's processing can be stopped, and then resumed in the handler on the captured queue object.