### PR TITLE
Optional trailing slash

### DIFF
--- a/tests/test_router.cpp
+++ b/tests/test_router.cpp
@@ -85,6 +85,9 @@ TEST_F(Router, StatelessRouteProcessor){
 
     processRequest(RequestType::POST, "/any");
     checkResponse("Any!");
+
+    processRequest(RequestType::POST, "/any/");
+    checkResponse("Any!");
 }
 
 struct NameState{

--- a/tests/test_router.cpp
+++ b/tests/test_router.cpp
@@ -88,6 +88,10 @@ TEST_F(Router, StatelessRouteProcessor){
 
     processRequest(RequestType::POST, "/any/");
     checkResponse("Any!");
+
+    setTrailingSlashMode(whaleroute::TrailingSlashMode::Strict);
+    processRequest(RequestType::POST, "/any/");
+    checkResponse("/404");
 }
 
 struct NameState{


### PR DESCRIPTION
Now trailing slash in route paths is optional by default, e.g. it's removed during registration and matching. This behaviour can be disabled by passing TrailingSlashMode::Strict to the router's setTrailingSlashMode() method.